### PR TITLE
Fix config address in Motor.py

### DIFF
--- a/Slush/Motor.py
+++ b/Slush/Motor.py
@@ -49,7 +49,7 @@ class Motor(sBoard):
             self.setOverCurrent(2000)
             self.setMicroSteps(16)
             self.setCurrent(70, 90, 100, 100)
-            self.setParam([0x1A, 16], 0x3608)
+            self.setParam([0x18, 16], 0x3608)
         if self.boardInUse == 1:
             self.setParam([0x1A, 16], 0x3608)
             self.setCurrent(100, 120, 140, 140)
@@ -246,7 +246,7 @@ class Motor(sBoard):
     def resetDev(self):
         self.xfer(LReg.RESET_DEVICE)
         if self.boardInUse == 1: self.setParam([0x1A, 16], 0x3608)
-        if self.boardInUse == 0: self.setParam([0x1A, 16], 0x3608)
+        if self.boardInUse == 0: self.setParam([0x18, 16], 0x3608)
 
     ''' stop the motor using the decel '''
     def softStop(self):


### PR DESCRIPTION
This request will fixes two references to the config address in Motor.py  to work with both the Model D (L6480) and Model XLT (L6470) boards. One reference is in initPeripherals() and the other is in resetDev()